### PR TITLE
Adding support for numeric keyboard

### DIFF
--- a/MOBILE_API.xml
+++ b/MOBILE_API.xml
@@ -2574,7 +2574,35 @@
         <param name="supportsDynamicSubMenus" type="Boolean" mandatory="false">
             <description>If true, the head unit supports dynamic sub-menus by sending OnUpdateSubMenu notifications. If true, you should not send AddCommands that attach to a parentID for an AddSubMenu until OnUpdateSubMenu is received with the menuID. At that point, you should send all AddCommands with a parentID that match the menuID. If not set, assume false.</description>
         </param>
-    </struct>  
+    </struct>
+
+    <enum name="KeyboardLayout" since="3.0">
+        <description>Enumeration listing possible keyboard layouts.</description>
+        <element name="QWERTY" />
+        <element name="QWERTZ" />
+        <element name="AZERTY" />
+        <element name="NUMERIC" since="7.1"/>
+    </enum>
+
+    <struct name="ConfigurableKeyboards" since="7.1">
+        <description>
+          Describes number of cofigurable Keys for Special characters.
+        </description>
+        <param name="keyboardLayout" type="KeyboardLayout" mandatory="true"/>
+        <param name="numConfigurableKeys" type="Integer" mandatory="true"/>
+    </struct>
+
+    <struct name="KeyboardCapabilities" since="7.1">
+        <param name="maskInputCharactersSupported" type="Boolean" mandatory="false" since="7.1" >
+            <description>Availability of capability to mask input characters using keyboard. True: Available, False: Not Available</description>
+        </param>
+        <param name="supportedKeyboardLayouts" type="KeyboardLayout" minsize="1" maxsize="1000" array="true" mandatory="false" since="7.1" >
+            <description>Supported keyboard layouts by HMI.</description>
+        </param>
+        <param name="configurableKeys" type="ConfigurableKeyboards" minsize="1" maxsize="1000" array="true" mandatory="false" since="7.1" >
+            <description>Get Number of Keys for Special characters, App can customize as per their needs.</description>
+        </param>
+    </struct>
 
     <struct name="WindowCapability" since="6.0">
         <param name="windowID" type="Integer" mandatory="false">
@@ -2610,6 +2638,9 @@
         </param>
         <param name="dynamicUpdateCapabilities" type="DynamicUpdateCapabilities" mandatory="false" since="7.0">
             <description>Contains the head unit's capabilities for dynamic updating features declaring if the module will send dynamic update RPCs.</description>
+        </param>
+        <param name="keyboardCapabilities"  type="KeyboardCapabilities" mandatory="false" since="7.1">
+            <description>See KeyboardCapabilities</description>
         </param>
     </struct>
 
@@ -2721,14 +2752,7 @@
         <param name="trim" type="String" maxlength="500" mandatory="false">
             <description>Trim of the vehicle, e.g. SE</description>
         </param>
-    </struct>   
-
-    <enum name="KeyboardLayout" since="3.0">
-        <description>Enumeration listing possible keyboard layouts.</description>
-        <element name="QWERTY" />
-        <element name="QWERTZ" />
-        <element name="AZERTY" />
-    </enum>         
+    </struct>    
     
     <enum name="KeyboardEvent" since="3.0">
         <description>Enumeration listing possible keyboard events.</description>

--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ Enumeration listing possible keyboard layouts.
 |`QWERTY`||
 |`QWERTZ`||
 |`AZERTY`||
+|`NUMERIC`||
 
 
 ### KeyboardEvent
@@ -2328,6 +2329,26 @@ Contains information about on-screen preset capabilities.
 |`supportsDynamicSubMenus`|Boolean|False|If true, the head unit supports dynamic sub-menus by sending OnUpdateSubMenu notifications. If true, you should not send AddCommands that attach to a parentID for an AddSubMenu until OnUpdateSubMenu is received with the menuID. At that point, you should send all AddCommands with a parentID that match the menuID. If not set, assume false.|
 
 
+### ConfigurableKeyboards
+Describes number of cofigurable Keys for Special characters.
+
+##### Parameters
+| Value |  Type | Mandatory | Description |
+| ---------- | ---------- |:-----------: |:-----------:|
+|`keyboardLayout`|KeyboardLayout|True|
+|`numConfigurableKeys`|Integer|True|
+
+
+### KeyboardCapabilities
+##### Parameters
+
+| Value |  Type | Mandatory | Description |
+| ---------- | ---------- |:-----------: |:-----------:|
+|`maskInputCharactersSupported`|Boolean|False|Availability of capability to mask input characters using keyboard. True: Available, False: Not Available.|
+|`supportedKeyboardLayouts`|KeyboardLayout[]|False|Supported keyboard layouts by HMI.|
+|`configurableKeys`|ConfigurableKeyboards[]|False|Get Number of Keys for Special characters, App can customize as per their needs.|
+
+
 ### WindowCapability
 ##### Parameters
 
@@ -2343,7 +2364,7 @@ Contains information about on-screen preset capabilities.
 |`softButtonCapabilities`|SoftButtonCapabilities[]|False|The number of soft buttons available on-window and the capabilities for each button.|
 |`menuLayoutsAvailable`|MenuLayout[]|False|An array of available menu layouts. If this parameter is not provided, only the `LIST` layout is assumed to be available|
 |`dynamicUpdateCapabilities`|DynamicUpdateCapabilities|False|Contains the head unit's capabilities for dynamic updating features declaring if the module will send dynamic update RPCs.|
-
+|`keyboardCapabilities`|KeyboardCapabilities|False|See KeyboardCapabilities.|
 
 ### WindowTypeCapabilities
 ##### Parameters


### PR DESCRIPTION
Implements [FORDTCN-7949](https://adc.luxoft.com/jira/browse/FORDTCN-7949)

This PR is **ready** for review.

### Summary
There is a need in adding support for numeric keyboard. To solve this problem new struct "KeyboardCapabilities" is added to Mobile API to inform apps about keyboard capabilities of HMI. Also "NUMERIC" value is added to "KeyboardLayout" enum. This enum value should allow apps to use numeric keypad.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)